### PR TITLE
Fixing bugs

### DIFF
--- a/mymoneytracker/mymoneytracker/MainWindow.xaml
+++ b/mymoneytracker/mymoneytracker/MainWindow.xaml
@@ -29,7 +29,7 @@
                 <Canvas>
                     <Label Content="Here you can view all recent transactions and add new ones" HorizontalAlignment="Left" VerticalAlignment="Top" Canvas.Left="10" Canvas.Top="10"/>
 
-                    <DataGrid x:Name="Recent_Transactions" HorizontalAlignment="Left" SelectionMode="Single" Height="443" VerticalAlignment="Top" Width="872" ItemsSource="{Binding Saved}"
+                    <DataGrid x:Name="Recent_Transactions" CanUserDeleteRows="False" HorizontalAlignment="Left" SelectionMode="Single" Height="443" VerticalAlignment="Top" Width="872" ItemsSource="{Binding Saved}"
                             SelectedItem="{Binding SelectedTransaction, Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="False" Canvas.Left="10" Canvas.Top="162" >
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Id" Binding="{Binding Id}" Width="*" Visibility="Hidden" IsReadOnly="True"/>
@@ -44,7 +44,7 @@
                     <DatePicker x:Name="dpDate" Canvas.Left="10" Canvas.Top="50" Width="120" SelectedDate="{Binding NewTransaction.Date, Mode=TwoWay}"/>
 
                     <TextBox x:Name="tbAmount" Height="23" Canvas.Left="10" TextWrapping="Wrap" Canvas.Top="90" Width="120" GotFocus="TbAmount_GotFocus" Style="{StaticResource TextErrorStyle}">
-                        <Binding Path="NewTransaction.Amount" Mode="TwoWay" ValidatesOnDataErrors="True" UpdateSourceTrigger="PropertyChanged">
+                        <Binding Path="NewTransaction.Amount" Mode="TwoWay" StringFormat="$###0.00" ValidatesOnDataErrors="True" UpdateSourceTrigger="PropertyChanged">
                             <Binding.ValidationRules>
                                 <ExceptionValidationRule></ExceptionValidationRule>
                             </Binding.ValidationRules>
@@ -87,7 +87,7 @@
                     <Label Content="Here you can view all classification rules and add new ones" HorizontalAlignment="Left" VerticalAlignment="Top" Canvas.Left="10" Canvas.Top="10"/>
                     <Label x:Name="ruleErrorContent" Content="" Canvas.Left="327" Canvas.Top="87" Height="42" Width="297" Foreground="Red"/>
                     <Button Content="Delete Rule" Click="DeleteRuleButtonClick" Canvas.Left="169" Canvas.Top="127" Width="120"/>
-                    <DataGrid x:Name="Rules_List" SelectionMode="Single" CellEditEnding="Rules_CellEditEnding" HorizontalAlignment="Left" Height="443" VerticalAlignment="Top" Width="872" ItemsSource="{Binding Rules}"
+                    <DataGrid x:Name="Rules_List" SelectionMode="Single" CanUserDeleteRows="False" CellEditEnding="Rules_CellEditEnding" HorizontalAlignment="Left" Height="443" VerticalAlignment="Top" Width="872" ItemsSource="{Binding Rules}"
                         SelectedItem="{Binding SelectedRule, Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="False" Canvas.Left="10" Canvas.Top="162">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Rule Name" Binding="{Binding Rule_name}" Width="*" />

--- a/mymoneytracker/mymoneytracker/MainWindow.xaml.cs
+++ b/mymoneytracker/mymoneytracker/MainWindow.xaml.cs
@@ -96,7 +96,7 @@ namespace mymoneytracker
         }
         private void TbAmount_GotFocus(object sender, RoutedEventArgs e)
         {
-            if(tbAmount.Text == "0")
+            if(tbAmount.Text == "$0.00")
                 tbAmount.Text = "";
         }
         private void TbPayee_GotFocus(object sender, RoutedEventArgs e)

--- a/mymoneytracker/mymoneytracker/StartingBalanceDialog.xaml
+++ b/mymoneytracker/mymoneytracker/StartingBalanceDialog.xaml
@@ -9,6 +9,13 @@
     <StackPanel Margin="0,0,0,0">
         <TextBlock x:Name="sbprompttext" Text="Enter your starting bank account balance below. Example format: 1234.56" Height="26" />
         <TextBox x:Name="ResponseTextBox" Height="28" />
-        <Button Content="OK" Click="OKButton_Click" Height="22" />
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition></ColumnDefinition>
+                <ColumnDefinition></ColumnDefinition>
+            </Grid.ColumnDefinitions>
+            <Button Content="OK" Click="OKButton_Click" Height="22" Grid.Column="0"/>
+            <Button Content="Cancel" Click="CloseButton_Click" Height="22" Grid.Column="1"/>
+        </Grid>
     </StackPanel>
 </Window>

--- a/mymoneytracker/mymoneytracker/StartingBalanceDialog.xaml.cs
+++ b/mymoneytracker/mymoneytracker/StartingBalanceDialog.xaml.cs
@@ -34,5 +34,10 @@ namespace mymoneytracker
         {
             DialogResult = true;
         }
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+            
+        }
     }
 }

--- a/mymoneytracker/mymoneytracker/ViewModels/MainViewModel.cs
+++ b/mymoneytracker/mymoneytracker/ViewModels/MainViewModel.cs
@@ -53,8 +53,8 @@ namespace mymoneytracker.ViewModels
                     }
                     else
                     {
-                        err = "invalid input";
-                        continue;
+                        set = true;
+                        System.Windows.Application.Current.Shutdown();
                     }
                 }                
             }


### PR DESCRIPTION
The Amount textbox on the Transactions tab doesn't allow decimal amounts like 5.75
The Delete key on the keyboard deletes transactions from the data grids on the Transactions and Rules tab. It doesn't delete them from the database, only the grid.
The Initial Configuration startup window reopens everytime if you close it without entering a value. You have to close the application using Task Manager.​